### PR TITLE
Update deployment workflow to output HTML to _site directory and ignore it in .gitignore

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
       - name: AsciiDoc to HTML
-        run: bundle exec asciidoctor -a toc="left" -a toclevels=2 README.adoc -o docs/index.html
+        run: bundle exec asciidoctor -a toc="left" -a toclevels=2 README.adoc -o _site/index.html
       - uses: actions/upload-pages-artifact@v3
   deploy:
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 README.html
 README.pdf
 Gemfile.lock
+_site/


### PR DESCRIPTION
build is success: https://github.com/rubocop/capybara-style-guide/actions/runs/13928880395/job/38980620414